### PR TITLE
Add fixed column width

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -38,7 +38,7 @@ module Annotate
   OTHER_OPTIONS = [
     :ignore_columns, :skip_on_db_migrate, :wrapper_open, :wrapper_close,
     :wrapper, :routes, :hide_limit_column_types, :hide_default_column_types,
-    :ignore_routes, :active_admin
+    :ignore_routes, :active_admin, :fixed_column_width
   ].freeze
   PATH_OPTIONS = [
     :require, :model_dir, :root_dir

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -349,7 +349,13 @@ module AnnotateModels
       indexes = retrieve_indexes_from_table(klass)
       return '' if indexes.empty?
 
-      max_size = indexes.collect{|index| index.name.size}.max + 1
+      fixed_column_width = options[:fixed_column_width].to_i
+      if fixed_column_width > 0
+        max_size = fixed_column_width + 1
+      else
+        max_size = indexes.collect{|index| index.name.size}.max + 1
+      end
+
       indexes.sort_by(&:name).each do |index|
         index_info << if options[:format_markdown]
                         final_index_string_in_markdown(index)
@@ -883,6 +889,11 @@ module AnnotateModels
     end
 
     def max_schema_info_width(klass, options)
+      fixed_column_width = options[:fixed_column_width].to_i
+      if fixed_column_width > 0
+        return fixed_column_width + 1
+      end
+
       if with_comments?(klass, options)
         max_size = klass.columns.map do |column|
           column.name.size + (column.comment ? column.comment.size : 0)


### PR DESCRIPTION
## Issue
when a new column is added, all of the annotations can be changed. this adds unnecessary changes and messes up the `git diff`. 

## Solution
This PR adds an option to use pre-defined length for the column names. which we can manually set to possible max length of Mysql column.