### PR TITLE
Update options for rake tasks

### DIFF
--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -48,6 +48,7 @@ task annotate_models: :environment do
   options[:hide_limit_column_types] = Annotate.fallback(ENV['hide_limit_column_types'], '')
   options[:hide_default_column_types] = Annotate.fallback(ENV['hide_default_column_types'], '')
   options[:with_comment] = Annotate.fallback(ENV['with_comment'], '')
+  options[:fixed_column_width] = ENV.fetch('fixed_column_width', nil)
 
   AnnotateModels.do_annotations(options)
 end


### PR DESCRIPTION
`rake db:migrate` does not run annotation with the new option(`fixed-column-width`)
to run annotation as a rake task, we need to pass new option to the rake task. 